### PR TITLE
Allow replicate_source_db to be passed on

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -15,6 +15,7 @@ resource "aws_db_instance" "default" {
   backup_window = "${var.backup_window}"
   backup_retention_period  = "${var.backup_retention_period}"
   storage_encrypted = "${var.storage_encrypted}"
+  replicate_source_db = "$(var.replicate_source_db)"
 
   lifecycle {
      ignore_changes = ["password"]


### PR DESCRIPTION
Automated fallout tracker would like to set up a replica