### PR TITLE
feat(rds): remove engine_version variable

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -3,7 +3,6 @@ resource "aws_db_instance" "default" {
   username = "${var.username}"
   password = "${var.password}"
   engine = "${var.engine}"
-  engine_version = "${var.engine_version}"
   instance_class = "${var.instance_class}"
   multi_az = "${var.multi_az}"
   port = "${var.port}"

--- a/variables.tf
+++ b/variables.tf
@@ -35,11 +35,6 @@ variable "engine" {
   default = "mysql"
 }
 
-variable "engine_version" {
-  description = "Engine version you want to use"
-  default = "5.7.17"
-}
-
 variable "instance_class" {
   description = "Instance class you want to use"
   default = "db.m4.large"


### PR DESCRIPTION
Fix for:
aws_db_instance.default: Error modifying DB Instance tf-0065b632739c3fc8e6afda9a1e: InvalidParameterCombination: Cannot upgrade postgres from 9.6.6 to 9.6.2