### PR TITLE
fix: restore engine_version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A terraform module for managing RDS instances
 Defaults:
 
 - `engine` - The type of RDS isntance you want to use. Defaults to mysql
-- `engine_version` - The RDS version you want to use. Defaults to 5.7.17
+- `engine_version` - The RDS version you want to use. Defaults to 5.7.23
 - `instance_class` - The RDS instance class. Defaults to db.m4.large
 - `multi_az` - Specifies if the RDS instance is multi-AZ. Defaults to true
 - `port` - RDS port. Defaults to 3306

--- a/instance.tf
+++ b/instance.tf
@@ -3,6 +3,7 @@ resource "aws_db_instance" "default" {
   username = "${var.username}"
   password = "${var.password}"
   engine = "${var.engine}"
+  engine_version = "${var.engine_version}"
   instance_class = "${var.instance_class}"
   multi_az = "${var.multi_az}"
   port = "${var.port}"

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,11 @@ variable "engine" {
   default = "mysql"
 }
 
+variable "engine_version" {
+  description = "Engine version you want to use"
+  default = "5.7.23"
+}
+
 variable "instance_class" {
   description = "Instance class you want to use"
   default = "db.m4.large"


### PR DESCRIPTION
This 'engine_version' module parameter is still documented in the README but was removed from the code for reasons that are unclear. This adds it back.